### PR TITLE
update Cake and NuGet deoendencies to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ xtc-api-key
 xtc-email
 .idea
 .vs/
+/source/Cake.ExtendedNuGet.sln.DotSettings.user

--- a/source/Cake.ExtendedNuGet.Tests/Cake.ExtendedNuGet.Tests.csproj
+++ b/source/Cake.ExtendedNuGet.Tests/Cake.ExtendedNuGet.Tests.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.33.0" />
-    <PackageReference Include="Cake.Core" Version="0.33.0" />
-    <PackageReference Include="Cake.Testing" Version="0.33.0" />
-    <PackageReference Include="NuGet.Packaging" Version="5.0.2" PrivateAssets="All" />
-    <PackageReference Include="NuGet.Protocol" Version="5.0.2" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="0.38.5" />
+    <PackageReference Include="Cake.Core" Version="0.38.5" />
+    <PackageReference Include="Cake.Testing" Version="0.38.5" />
+    <PackageReference Include="NuGet.Packaging" Version="5.8.1" PrivateAssets="All" />
+    <PackageReference Include="NuGet.Protocol" Version="5.8.1" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/source/Cake.ExtendedNuGet.Tests/Cake.ExtendedNuGet.Tests.csproj
+++ b/source/Cake.ExtendedNuGet.Tests/Cake.ExtendedNuGet.Tests.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.38.5" />
-    <PackageReference Include="Cake.Core" Version="0.38.5" />
-    <PackageReference Include="Cake.Testing" Version="0.38.5" />
-    <PackageReference Include="NuGet.Packaging" Version="5.8.1" PrivateAssets="All" />
-    <PackageReference Include="NuGet.Protocol" Version="5.8.1" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="0.36.0" />
+    <PackageReference Include="Cake.Core" Version="0.36.0" />
+    <PackageReference Include="Cake.Testing" Version="0.36.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.4.0" PrivateAssets="All" />
+    <PackageReference Include="NuGet.Protocol" Version="5.4.0" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/source/Cake.ExtendedNuGet.Tests/Fakes/FakeCakeContext.cs
+++ b/source/Cake.ExtendedNuGet.Tests/Fakes/FakeCakeContext.cs
@@ -25,7 +25,7 @@ namespace Cake.ExtendedNuGet.Tests.Fakes
             var registry = new WindowsRegistry ();
             var toolRepo = new ToolRepository(environment);
             var config = new Core.Configuration.CakeConfigurationProvider(fileSystem, environment).CreateConfiguration(testsDir, new Dictionary<string, string>());
-            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, config, log);
+            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, config);
             var toolLocator = new ToolLocator(environment, toolRepo, toolResolutionStrategy);
             var processRunner = new ProcessRunner(fileSystem, environment, log, toolLocator, config);
             var dataService = new FakeCakeDataService();

--- a/source/Cake.ExtendedNuGet.Tests/Fakes/FakeCakeContext.cs
+++ b/source/Cake.ExtendedNuGet.Tests/Fakes/FakeCakeContext.cs
@@ -25,7 +25,7 @@ namespace Cake.ExtendedNuGet.Tests.Fakes
             var registry = new WindowsRegistry ();
             var toolRepo = new ToolRepository(environment);
             var config = new Core.Configuration.CakeConfigurationProvider(fileSystem, environment).CreateConfiguration(testsDir, new Dictionary<string, string>());
-            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, config);
+            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, config, log);
             var toolLocator = new ToolLocator(environment, toolRepo, toolResolutionStrategy);
             var processRunner = new ProcessRunner(fileSystem, environment, log, toolLocator, config);
             var dataService = new FakeCakeDataService();

--- a/source/Cake.ExtendedNuGet/Cake.ExtendedNuGet.csproj
+++ b/source/Cake.ExtendedNuGet/Cake.ExtendedNuGet.csproj
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.38.5" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="0.38.5" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="0.36.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="0.36.0" PrivateAssets="All" />
     <PackageReference Include="NuGet.Packaging" Version="5.4.0" PrivateAssets="All" />
     <PackageReference Include="NuGet.Protocol" Version="5.4.0" PrivateAssets="All" />
   </ItemGroup>

--- a/source/Cake.ExtendedNuGet/Cake.ExtendedNuGet.csproj
+++ b/source/Cake.ExtendedNuGet/Cake.ExtendedNuGet.csproj
@@ -21,10 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="NuGet.Packaging" Version="5.0.2" PrivateAssets="All" />
-    <PackageReference Include="NuGet.Protocol" Version="5.0.2" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="0.38.5" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="0.38.5" PrivateAssets="All" />
+    <PackageReference Include="NuGet.Packaging" Version="5.4.0" PrivateAssets="All" />
+    <PackageReference Include="NuGet.Protocol" Version="5.4.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
update Cake and NuGet deoendencies to
0.38.5 and 5.4.0
the NuGet dependencies are the same as in cake 0.38.5

Basically this is only about the NuGet dependencies.
NuGet 5.4.X allows us to build NuGet packages with net48, which 5.0.2 didn't

## Related Issue
We wanted to update our solutions to net48
Cake then told us, the old version NuGet didn't support solutions with net48.
Some discussions somewhere in github led us to the update of cake to 0.38.4 since that would update NuGet as well.
However, Cake.ExtendedNuGet would not work with the newer NuGet.
