### PR TITLE
(GH-53) bumped Cake to 1.0.0

### DIFF
--- a/source/Cake.ExtendedNuGet.Tests/Cake.ExtendedNuGet.Tests.csproj
+++ b/source/Cake.ExtendedNuGet.Tests/Cake.ExtendedNuGet.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.36.0" />
-    <PackageReference Include="Cake.Core" Version="0.36.0" />
-    <PackageReference Include="Cake.Testing" Version="0.36.0" />
+    <PackageReference Include="Cake.Common" Version="1.0.0" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" />
+    <PackageReference Include="Cake.Testing" Version="1.0.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/source/Cake.ExtendedNuGet.Tests/Fakes/FakeCakeArguments.cs
+++ b/source/Cake.ExtendedNuGet.Tests/Fakes/FakeCakeArguments.cs
@@ -6,40 +6,14 @@ namespace Cake.ExtendedNuGet.Tests.Fakes
 {
     internal sealed class FakeCakeArguments : ICakeArguments
     {
-        private readonly Dictionary<string, string> _arguments;
-
-        /// <summary>
-        /// Gets the arguments.
-        /// </summary>
-        /// <value>The arguments.</value>
-        public IReadOnlyDictionary<string, string> Arguments
-        {
-            get { return _arguments; }
-        }
+        private readonly Dictionary<string, ICollection<string>> _arguments;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CakeArguments"/> class.
         /// </summary>
         public FakeCakeArguments()
         {
-            _arguments = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Initializes the argument list.
-        /// </summary>
-        /// <param name="arguments">The arguments.</param>
-        public void SetArguments(IDictionary<string, string> arguments)
-        {
-            if (arguments == null)
-            {
-                throw new ArgumentNullException("arguments");
-            }
-            _arguments.Clear();
-            foreach (var argument in arguments)
-            {
-                _arguments.Add(argument.Key, argument.Value);
-            }
+            _arguments = new Dictionary<string, ICollection<string>>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -54,15 +28,9 @@ namespace Cake.ExtendedNuGet.Tests.Fakes
             return _arguments.ContainsKey(name);
         }
 
-        /// <summary>
-        /// Gets an argument.
-        /// </summary>
-        /// <param name="name">The argument name.</param>
-        /// <returns>The argument value.</returns>
-        public string GetArgument(string name)
+        public ICollection<string> GetArguments(string name)
         {
-            return _arguments.ContainsKey(name)
-                ? _arguments[name] : null;
+            return _arguments.TryGetValue(name, out var val) ? val : new List<string>();
         }
     }
 }

--- a/source/Cake.ExtendedNuGet.Tests/Fakes/FakeCakeContext.cs
+++ b/source/Cake.ExtendedNuGet.Tests/Fakes/FakeCakeContext.cs
@@ -25,7 +25,7 @@ namespace Cake.ExtendedNuGet.Tests.Fakes
             var registry = new WindowsRegistry ();
             var toolRepo = new ToolRepository(environment);
             var config = new Core.Configuration.CakeConfigurationProvider(fileSystem, environment).CreateConfiguration(testsDir, new Dictionary<string, string>());
-            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, config);
+            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, config, log);
             var toolLocator = new ToolLocator(environment, toolRepo, toolResolutionStrategy);
             var processRunner = new ProcessRunner(fileSystem, environment, log, toolLocator, config);
             var dataService = new FakeCakeDataService();

--- a/source/Cake.ExtendedNuGet/Cake.ExtendedNuGet.csproj
+++ b/source/Cake.ExtendedNuGet/Cake.ExtendedNuGet.csproj
@@ -39,8 +39,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Cake.Common" Version="0.36.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="0.36.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CakeContrib.Guidelines" Version="0.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION

## Description
bumped Cake.Core, Cake.Common and Cake.Testing to version 1.0.0
Had to change some of tests for that to compile again.

## Related Issue
fixes #53 

## Motivation and Context
https://cakebuild.net/blog/2021/02/cake-v1.0.0-released

## How Has This Been Tested?
Build, ran unittest and did a small manual integration test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
