### PR TITLE
(#95) switched building to .NET 6 rc2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,20 @@
 image: Visual Studio 2019
 
 #---------------------------------#
+#  Install .NET                   #
+#---------------------------------#
+install:
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
+  - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
+  - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 2.1.818 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 3.1.414 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 5.0.402 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.100-rc.2.21505.57 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+  - ps: dotnet --info
+  
+#---------------------------------#
 #  Build Script                   #
 #---------------------------------#
 build_script:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,23 @@ jobs:
       - name: Fetch all tags and branches
         run: git fetch --prune --unshallow
 
+      - uses: actions/setup-dotnet@v1.8.2
+        with:
+          # codecov and unittests need 2.1
+          dotnet-version: '2.1.818'
+      - uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: '3.1.414'
+      - uses: actions/setup-dotnet@v1.8.2
+        with:
+          # gitversion needs 5.0
+          dotnet-version: '5.0.402'
+      - uses: actions/setup-dotnet@v1.8.2
+        with:
+          # need at least .NET 6 rc2 to build
+          dotnet-version: '6.0.100-rc.2.21505.57'
+          include-prerelease: true
+
       - name: Cache Tools
         uses: actions/cache@v2.1.6
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,23 @@ jobs:
       with:
         fetch-depth: 0
 
+    - uses: actions/setup-dotnet@v1.8.2
+      with:
+        # codecov and unittests need 2.1
+        dotnet-version: '2.1.818'
+    - uses: actions/setup-dotnet@v1.8.2
+      with:
+        dotnet-version: '3.1.414'
+    - uses: actions/setup-dotnet@v1.8.2
+      with:
+        # gitversion needs 5.0
+        dotnet-version: '5.0.402'
+    - uses: actions/setup-dotnet@v1.8.2
+      with:
+        # need at least .NET 6 rc2 to build
+        dotnet-version: '6.0.100-rc.2.21505.57'
+        include-prerelease: true
+
     - name: Cache Tools
       uses: actions/cache@v2.1.6
       with:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "allowPrerelease": true,
+        "version": "6.0.100-rc.2",
+        "rollForward": "latestFeature"
+    }
+}


### PR DESCRIPTION
## Description

* setup a global.json to pin the .NET sdk to .NET 6 rc2
* setup .NET 2.1,3.1,5.0 and 6.0-rc2 in GitHub actions
* setup .NET 2.1,3.1,5.0 and 6.0-rc2 in AppVeyor

## Related Issue
#95 

## Motivation and Context
#95 

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Build-Pipeline


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
