### PR TITLE
Fixed deadlock on IsNuGetPublished

### DIFF
--- a/source/Cake.ExtendedNuGet.Tests/ExtendedNuGetTests.cs
+++ b/source/Cake.ExtendedNuGet.Tests/ExtendedNuGetTests.cs
@@ -70,6 +70,18 @@ namespace Cake.ExtendedNuGet.Tests
         }
 
         [Fact]
+        public void IsNugetPublishedInvalidSourceShouldBeFalse ()
+        {
+            var p = context.CakeContext.IsNuGetPublished (
+                "Xamarin.Android.Support.v4",
+                "23.1.1.0",
+                "https://api.nuget.org/v3/wrong.json"
+            );
+
+            Assert.False (p);
+        }
+
+        [Fact]
         public void NuGetPackageIdFromFile ()
         {
             var f = new FilePath ("./TestData/xamarin.android.support.v4.23.1.1.nupkg");


### PR DESCRIPTION
Whenever IsNuGetPublished is used with a source that returns a non-200 HTTP result, IsNugetPublished deadlocks and cake script stalls.

## Description
Getting general resource information from the NuGet repository is not caught, failing in background. Happens with any non-200 HTTP result. Error is now trapped and dismissed in same way as other errors when fetching dependency info of the package.

Logging was added so users can see the actual error when using `Diagnostic` verbosity.

Original issue can be easily replicated with the following script:

```C#
#addin nuget:?package=Cake.ExtendedNuGet&version=5.0.0

Task("Test")
    .Does(ctx =>
    {    
        // Note the nuget URL is actually missing the `api.` subdomain
        var exists = ctx.IsNuGetPublished(new FilePath("test.nupkg"), "https://nuget.org/v3/index.json");
        Console.Write($"Package exists: {exists}");
    });

RunTarget("Test");
```

## Motivation and Context
We are using private nuget repositories, which require user/password auth. API was replying with 401 causing the cake script to stall.

## How Has This Been Tested?
Published locally and tested with our own private nuget repository.

## Screenshots (if appropriate):
![image](https://github.com/cake-contrib/Cake.ExtendedNuGet/assets/1435258/9ef892ff-45f3-4eab-941f-7810e6e5fd62)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
